### PR TITLE
Added case of postgresql v9.4 for centos v7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -239,6 +239,11 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-1.noarch.rpm"
       }
+    },
+    "centos" => {
+      "7" => {
+        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-centos94-9.4-1.noarch.rpm"
+      }
     }
   },
   "9.3" => {


### PR DESCRIPTION
This cookbook raise and error when Chef try to install Postgresql 9.4 into Centos 7. 

This fix it.
